### PR TITLE
replace codemirror with embed block

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "developer",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "developer",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "MIT",
       "dependencies": {
         "@dvargas92495/codemirror": "^5.65.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "developer",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Develop and publish your own Roam extensions with the help of RoamJS!",
   "main": "./build/main.js",
   "scripts": {

--- a/src/features/sparql.tsx
+++ b/src/features/sparql.tsx
@@ -498,15 +498,6 @@ const SparqlQuery = ({
             <div>
               <CustomQueryEmbed uid={customQueryUid} />
             </div>
-            {/* <CodeMirror
-              value={codeValue}
-              options={{
-                mode: { name: "sparql" },
-                lineNumbers: true,
-                lineWrapping: true,
-              }}
-              onBeforeChange={(_, __, v) => setCodeValue(v)}
-            /> */}
             <div className="mt-2 inline-block w-full">
               <Label>
                 SPARQL Endpoint
@@ -604,7 +595,6 @@ const SparqlQuery = ({
               const customQuery = isQuery
                 ? getCodeFromBlock(getTextByBlockUid(customQueryUid))
                 : "";
-
               const labelUid = await createBlock({
                 node: {
                   text: getLabel({ outputFormat, label }),

--- a/src/features/sparql.tsx
+++ b/src/features/sparql.tsx
@@ -19,8 +19,6 @@ import {
   Checkbox,
   InputGroup,
 } from "@blueprintjs/core";
-import { Controlled as CodeMirror } from "@dvargas92495/react-codemirror2";
-import "@dvargas92495/codemirror/mode/sparql/sparql";
 import React, {
   useCallback,
   useEffect,
@@ -318,7 +316,6 @@ const SparqlQuery = ({
     WIKIDATA_ITEMS[0]
   );
   const [radioValue, setRadioValue] = useState("");
-  const [codeValue, setCodeValue] = useState("");
   const [showAdditionalOptions, setShowAdditionalOptions] = useState(false);
   const toggleAdditionalOptions = useCallback(
     () => setShowAdditionalOptions(!showAdditionalOptions),
@@ -393,18 +390,9 @@ const SparqlQuery = ({
 `
             : ""
         );
-    } else if (activeItem === "Custom Query") {
-      if (LIMIT_REGEX.test(codeValue)) {
-        return codeValue.replace(
-          LIMIT_REGEX,
-          (_, l) => `LIMIT ${Math.min(l, limit)}`
-        );
-      } else {
-        return `${codeValue}\nLIMIT ${limit}`;
-      }
     }
     return "";
-  }, [codeValue, radioValue, activeItem, limit, importQualifiers]);
+  }, [radioValue, activeItem, limit, importQualifiers]);
   const [pageResults, setPageResults] = useState<PageResult[]>([]);
   const searchQuery = useMemo(
     () => (activeItem === "Current Block" ? blockString : pageTitle),

--- a/src/utils/getCodeFromBlock.ts
+++ b/src/utils/getCodeFromBlock.ts
@@ -1,6 +1,7 @@
 const getCodeFromBlock = (content: string) =>
   content
     .replace(/^\s*```javascript(\n)?/, "")
+    .replace(/^\s*```sparql(\n)?/, "")
     .replace(/(\n)?```\s*$/, "")
     .replace(/^\s*`/, "")
     .replace(/`\s*$/, "");


### PR DESCRIPTION
Tried Query:

```
SELECT ?item ?itemLabel
WHERE
{
  ?item wdt:P31 wd:Q5.
  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
}
```

`Cannot read properties of undefined (reading 'bindings')`

https://github.com/RoamJS/developer/blob/35b3ee163b282f12452d9775f625037fae49b9ab/src/features/sparql.tsx#L142-L154

Data came back as:

![image](https://github.com/RoamJS/developer/assets/3792666/70ab86ac-21f1-4b3d-9bea-5b5f094b4b56)

